### PR TITLE
Adding .gitattributes for preserving lf line endings on reference files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/baselines/reference/* eol=lf


### PR DESCRIPTION
To help with https://github.com/sandersn/mini-typescript/issues/5 issue.